### PR TITLE
Add restarting of puma at deploying, fix shared dirs setup

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -12,14 +12,14 @@ set :keep_releases, 2
 
 set :app_path,   "#{fetch(:current_path)}"
 
-set :shared_paths, ["log/", "tmp/", "public/"]
-set :shared_files, [
+set :shared_dirs, fetch(:shared_dirs, []).push("log", "tmp", "public")
+set :shared_files, fetch(:shared_files, []).push(
     "config/puma.rb",
     "config/database.yml",
     "config/initializers/constants.rb",
     "config/initializers/google_parameters.rb",
     "config/environments/production.rb"
-]
+)
 
 #set :rails_env, 'production'
 #set :port, '22'
@@ -36,5 +36,8 @@ task :deploy do
     invoke :'bundle:install'
     # command "#{fetch (:bundle_prefix)} rake bootstrap"
     invoke :'rails:assets_precompile'
+    on :launch do
+      command %{systemctl --user restart puma-lvee.org}
+    end
   end
 end


### PR DESCRIPTION
Now puma is controlled by systemd service (inside of the user session), add
service restart to the deploy task.

Fix shared dirs setup for latest mina.